### PR TITLE
Allow non-litellm clients to use tools

### DIFF
--- a/promptic.py
+++ b/promptic.py
@@ -335,7 +335,7 @@ class Promptic:
             self.logger.debug(f"{kwargs = }")
             self.logger.debug(f"{self.cache = }")
 
-            if self.tools:
+            if self.tools and not self.openai_client: # assume oai clients support tools
                 assert litellm.supports_function_calling(self.model), (
                     f"Model {self.model} does not support function calling"
                 )


### PR DESCRIPTION
This bypasses the litellm tools check when another client is in place