### PR TITLE
Implement OpenAI schema pruning for Pydantic models and bump version to 5.5.0

### DIFF
--- a/tests/test_promptic.py
+++ b/tests/test_promptic.py
@@ -702,7 +702,7 @@ def test_memory_with_streaming(model, create_completion_fn):
     assert messages[3]["content"] == response2  # Second assistant response
 
 
-@pytest.mark.parametrize("model", CHEAP_MODELS)
+@pytest.mark.parametrize("model", REGULAR_MODELS)
 @pytest.mark.parametrize(
     "create_completion_fn", [openai_completion_fn, litellm_completion]
 )

--- a/uv.lock
+++ b/uv.lock
@@ -739,7 +739,7 @@ wheels = [
 
 [[package]]
 name = "promptic"
-version = "5.1.1"
+version = "5.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
- Add _to_openai_schema function to filter JSON-Schema keys accepted by OpenAI's function-calling interface.
- Update Promptic class methods to utilize the new schema pruning function.
- Change test parameterization from CHEAP_MODELS to REGULAR_MODELS for improved testing coverage.