### PR TITLE
Fix streaming tool calls and agent continuation

### DIFF
--- a/promptic.py
+++ b/promptic.py
@@ -227,6 +227,7 @@ class Promptic:
 
         return result
 
+
     def _completion(self, messages: list[dict], **kwargs):
         new_messages = self._set_anthropic_cache(messages)
         previous_messages = self.state.get_messages() if self.state else []
@@ -304,7 +305,7 @@ class Promptic:
             )
 
         if (self.completion_kwargs | kwargs).get("stream"):
-            return self._stream_response(response, call)
+            return self._stream_response(response, messages, call)
         else:
             content = response.choices[0].message.content
             result = self._parse_and_validate_response(content)
@@ -666,7 +667,7 @@ class Promptic:
                     call.inputs["messages"] = completion_messages
 
                 if self.completion_kwargs.get("stream"):
-                    return self._stream_response(response, call)
+                    return self._stream_response(response, messages, call)
 
                 for choice in response.choices:
                     # Handle tool calls if present
@@ -739,10 +740,12 @@ class Promptic:
 
         return wrapper
 
-    def _stream_response(self, response, call=None):
+    def _stream_response(self, response, messages, call=None):
         current_tool_calls = {}
         current_index = None
         accumulated_response = ""
+        completed_tool_calls = []
+        tool_result_messages = []
 
         for part in response:
             # Handle tool calls in streaming mode
@@ -788,6 +791,7 @@ class Promptic:
                                             self.logger.warning(
                                                 f"[DRY RUN] Would have called {tool_info['name']} with {function_args}"
                                             )
+                                            function_response = f"[DRY RUN] Would have called {tool_info['name']} with {function_args}"
                                         else:
                                             self.logger.debug(
                                                 f"Calling tool {tool_info['name']}({function_args}) using {self.model = }"
@@ -798,7 +802,27 @@ class Promptic:
                                                     fn, function_args
                                                 )
                                             )
-                                            fn(**function_args)
+                                            function_response = fn(**function_args)
+
+                                        # Create tool result message
+                                        tool_result_msg = {
+                                            "tool_call_id": tool_info["id"],
+                                            "role": "tool",
+                                            "name": tool_info["name"],
+                                            "content": to_json(function_response),
+                                        }
+                                        tool_result_messages.append(tool_result_msg)
+
+                                        # Store the complete tool call info for later reconstruction
+                                        completed_tool_calls.append({
+                                            "id": tool_info["id"],
+                                            "type": "function",
+                                            "function": {
+                                                "name": tool_info["name"],
+                                                "arguments": args_str
+                                            }
+                                        })
+
                                         # Clear after successful execution
                                         del current_tool_calls[current_index]
                                 except json.JSONDecodeError:
@@ -807,8 +831,29 @@ class Promptic:
                         except Exception as e:
                             self.logger.error(f"Error executing tool: {e}")
                             self.logger.exception(e)
-                            continue
+                            # Create error response for the tool call
+                            if current_index in current_tool_calls:
+                                tool_info = current_tool_calls[current_index]
+                                tool_result_msg = {
+                                    "tool_call_id": tool_info["id"],
+                                    "role": "tool",
+                                    "name": tool_info["name"],
+                                    "content": f"Error calling tool {tool_info['name']}: {e}",
+                                }
+                                tool_result_messages.append(tool_result_msg)
 
+                                # Store the tool call info even for errors
+                                completed_tool_calls.append({
+                                    "id": tool_info["id"],
+                                    "type": "function",
+                                    "function": {
+                                        "name": tool_info["name"],
+                                        "arguments": tool_info["arguments"]
+                                    }
+                                })
+
+                               # del current_tool_calls[current_index]
+                            continue
             # Stream regular content and accumulate
             if (
                 hasattr(part.choices[0].delta, "content")
@@ -817,13 +862,44 @@ class Promptic:
                 content = part.choices[0].delta.content
                 accumulated_response += content
                 yield content
+        # After streaming is complete, add messages to conversation and state
+        if completed_tool_calls:
+            # Create assistant message with tool calls
+            function_message = {
+                "role": "assistant",
+                "content": accumulated_response,
+                "tool_calls": completed_tool_calls
+            }
+            # Add messages to conversation and state
+            messages.append(function_message)
+            if self.state:
+                self.state.add_message(function_message)
 
-        # After streaming is complete, add to state if memory is enabled
-        if self.state:
-            self.state.add_message(
-                {"content": accumulated_response, "role": "assistant"}
-            )
-
+            # Add all tool result messages
+            for tool_result in tool_result_messages:
+                messages.append(tool_result)
+                if self.state:
+                    self.state.add_message(tool_result)
+                # trigger a new agent completion with the tool result in state
+                if self.state:
+                    # Continue the conversation with the tool results (force non-streaming)
+                    completion_messages, next_response = self._completion([], stream=False)
+                    
+                    # Handle the next response (could have more tool calls or final content)
+                    if hasattr(next_response.choices[0].message, "tool_calls") and next_response.choices[0].message.tool_calls:
+                        # More tool calls - this needs to be handled recursively, but for now just yield the content
+                        if next_response.choices[0].message.content:
+                            yield next_response.choices[0].message.content
+                    else:
+                        # Final response content
+                        if next_response.choices[0].message.content:
+                            yield next_response.choices[0].message.content
+        else:
+            # No tool calls, just add the regular assistant response
+            if self.state:
+                self.state.add_message(
+                    {"content": accumulated_response, "role": "assistant"}
+                )
         if call and self.weave_client:
             self.weave_client.finish_call(call, output=accumulated_response)
 


### PR DESCRIPTION
Streaming w/ Memory needed to:
- include tool calls in the memory
- add the results to the memory
- immediately trigger a generation post-call

This PR adds that functionality. 

Addresses #48 